### PR TITLE
Allow for relocation of values without set 'registry' and 'tag'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /bin/
 /dist/
 /examples/
+/.vscode/
 **~
 **.tgz
 /out/

--- a/pkg/chartutils/values.go
+++ b/pkg/chartutils/values.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/utils"
@@ -123,8 +124,12 @@ func (v *ValuesImageElement) Relocate(prefix string) error {
 		return fmt.Errorf("failed to parse relocated URL: %v", err)
 	}
 
-	v.Registry = newRef.Context().Registry.RegistryStr()
-	v.Repository = newRef.Context().RepositoryStr()
+	if slices.Contains(v.foundFields, "registry") {
+		v.Registry = newRef.Context().Registry.RegistryStr()
+		v.Repository = newRef.Context().RepositoryStr()
+	} else {
+		v.Repository = newRef.Context().Name()
+	}
 	return nil
 }
 
@@ -183,6 +188,14 @@ func parseValuesImageElement(data map[string]interface{}) *ValuesImageElement {
 		if !ok {
 			// digest is optional
 			if k == "digest" {
+				continue
+			}
+			// empty registry may be acceptable
+			if k == "registry" {
+				continue
+			}
+			// empty registry may be acceptable
+			if k == "tag" {
 				continue
 			}
 			return nil


### PR DESCRIPTION
A lot of established helm charts:
- Do not separate image refs into 'registry' and 'repository'
- Use '.Chart.appVersion' by default if 'tag' is not specified

For example, see Helm charts for: cert-manager, external-dns, opentelemetry-operator

This change should allow for relocating values files for charts that use 'repository' as a complete image ref. I.e. 'repository: quay.io/jetstack/cert-manager-cainjector'